### PR TITLE
update docker.sh: read cfg form database.properties, init run schema.sql

### DIFF
--- a/app/data/docker.sh
+++ b/app/data/docker.sh
@@ -1,3 +1,12 @@
+#!/bin/bash
+set -x
+# Read properties from database.properties
+while IFS='=' read -r key value
+do
+    key=$(echo $key | tr '.' '_')
+    eval "${key}='${value}'"
+done < database.properties
+
 # Install MySQL
 
 docker stop mysql
@@ -5,13 +14,15 @@ docker stop mysql
 docker rm mysql
 
 docker create --name mysql \
-    -e MYSQL_DATABASE={dbname} \
-    -e MYSQL_USER={username} \
-    -e MYSQL_PASSWORD={password} \
-    -p 3306:3306 \
+    -e MYSQL_DATABASE=${name} \
+    -e MYSQL_USER=${user} \
+    -e MYSQL_PASSWORD=${pass} \
+    -e MYSQL_RANDOM_ROOT_PASSWORD=true \
+    -v $(pwd)/schema.sql:/docker-entrypoint-initdb.d/schema.sql \
+    -p ${port}:3306 \
     mysql:8.0.36
 
-docker network connect app mysql
+#docker network connect app mysql
 
 docker update --restart=always mysql
 


### PR DESCRIPTION
I've updated docker.sh so that it reads the configuration from database.properties and can initialize the database by schema.sql.